### PR TITLE
Add local development scaffold for Manhwa Translate extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Manhwa Translate Local Development
+
+This repository contains a reverse-engineered Chrome extension for translating manhwa/manga.
+
+## Setup
+
+1. Install dependencies
+
+   ```
+   npm install
+   ```
+
+2. Build the extension in watch mode:
+
+   ```
+   npm run dev
+   ```
+
+   This builds the extension to the `dist/` folder and watches for changes.
+
+3. Load the unpacked extension:
+   - Open `chrome://extensions` in Chrome.
+   - Enable *Developer mode*.
+   - Click *Load unpacked* and select the `dist/` folder.
+
+## Development Workflow
+
+- Source files are located in `src/`.
+- Content script: `src/content.js`
+- Background service worker: `src/background.js`
+
+Update these files and run `npm run dev` to rebuild automatically.
+
+## Disclaimer
+
+This project is for educational purposes and does not include remote APIs or proprietary assets from the original extension.

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
-  "name": "manga-translator-recovery",
+  "name": "manhwa-translate-local",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "private": true,
+  "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "dev": "vite build --watch",
+    "build": "vite build"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "type": "module"
+  "devDependencies": {
+    "vite": "^5.4.0",
+    "@crxjs/vite-plugin": "^1.0.16"
+  }
 }

--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,13 @@
+// Background service worker for the local development version of the
+// Manhwa Translator extension.
+//
+// The background script runs in a separate context from the content
+// script and can handle events such as installation, messaging, or
+// network requests.  This stub simply logs when the service worker
+// starts and when the extension is installed or updated.
+
+console.log('[Manhwa Translate Local] background service worker started');
+
+chrome.runtime.onInstalled.addListener(() => {
+  console.log('[Manhwa Translate Local] extension installed or updated');
+});

--- a/src/content.js
+++ b/src/content.js
@@ -1,0 +1,28 @@
+// Content script for the local development version of the
+// Manhwa Translator extension.
+//
+// This stub demonstrates that your content script is being injected
+// correctly by adding a small banner to the page and logging to the
+// console.  Replace the contents of this file with your recovered
+// translation logic when ready.
+
+console.log('[Manhwa Translate Local] content script loaded', window.location.href);
+
+// Create a banner element to indicate that the content script is active.
+const banner = document.createElement('div');
+banner.textContent = 'Manhwa Translator content script active';
+banner.style.position = 'fixed';
+banner.style.zIndex = '2147483647';
+banner.style.bottom = '10px';
+banner.style.right = '10px';
+banner.style.padding = '6px 10px';
+banner.style.background = 'rgba(0, 128, 0, 0.8)';
+banner.style.color = '#fff';
+banner.style.borderRadius = '4px';
+banner.style.fontSize = '12px';
+
+// Append the banner to the document root so it overlays the page.
+document.documentElement.appendChild(banner);
+
+// Remove the banner after five seconds to avoid cluttering the page.
+setTimeout(() => banner.remove(), 5000);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,0 +1,43 @@
+{
+  "manifest_version": 3,
+  "name": "Manhwa Translator (Local)",
+  "version": "0.0.0",
+  "description": "Local development scaffold for the Manhwa Translator extension.",
+  "action": {
+    "default_title": "Manhwa Translator (Local)"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "permissions": [
+    "scripting",
+    "storage"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  "content_scripts": [
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "content.js"
+      ],
+      "run_at": "document_idle"
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "assets/*",
+        "fonts/*",
+        "icons/*",
+        "*.wasm"
+      ],
+      "matches": [
+        "<all_urls>"
+      ]
+    }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vite';
+import { crx } from '@crxjs/vite-plugin';
+
+// Import the extension manifest. During the build the CRX plugin
+// injects version numbers and ensures the correct structure for
+// Chrome Manifest V3. See src/manifest.json for details.
+import manifest from './src/manifest.json';
+
+// Vite configuration for bundling a Chrome extension.  The CRX plugin
+// automatically handles most of the boilerplate associated with
+// manifest versioning and code output.  Setting `sourcemap: true` on
+// the build ensures that you can debug your extension easily in
+// Chrome DevTools.
+export default defineConfig({
+  plugins: [crx({ manifest })],
+  build: {
+    sourcemap: true,
+    // Emit the build artefacts into the `dist` folder at the project
+    // root.  When running `npm run dev`, Vite will watch for file
+    // changes and rebuild the extension automatically.
+    outDir: 'dist',
+  },
+});


### PR DESCRIPTION
This PR adds a local development setup for the Manhwa Translate extension.

- Adds a minimal MV3 `manifest.json` under `src/` for the local build.
- Introduces stub `content.js` and `background.js` in `src/` that log messages and set up a basic service worker.
- Adds `vite.config.ts` and installs `vite` and `@crxjs/vite-plugin` to bundle the extension.
- Updates `package.json` with dev dependencies and scripts (`npm run dev` and `npm run build`).
- Adds a README with setup instructions explaining how to build and load the extension locally.

These changes make it possible to run and iterate on the extension without relying on the original build pipeline.